### PR TITLE
Move domains from game.airmash.steamroller.tk to game.airmash.cc

### DIFF
--- a/games.txt
+++ b/games.txt
@@ -3,8 +3,8 @@ eu|1|ffa2|Free For All #2|FFA #2|eu.airmash.online|ffa2
 eu|2|ctf1|Capture The Flag #1|CTF #1|lags.win|ctf
 eu|2|ctf2|Capture The Flag #2|CTF #2 (dev)|dev.airbattle.xyz|ctf
 eu|3|btr1|Battle Royale #1|BTR #1|eu.airmash.online|btr1
-us|1|ffa1|Free For All #1|FFA #1|us.airmash.online|ffa
+us|1|ffa1|Free For All #1|FFA #1|game.airmash.cc|ffa
 us|1|ffa2|Free For All #2|FFA #2|airmash.trackjunkies.org|ffa1
-us|2|ctf1|Capture The Flag #1|CTF #1|us.airmash.online|ctf
+us|2|ctf1|Capture The Flag #1|CTF #1|game.airmash.cc|ctf
 us|3|btr1|Battle Royale #1|BTR #1|us.airmash.online|btr1
-us|4|dev|Test Server|Test Server|us.airmash.online|dev
+us|4|dev|Test Server|Test Server|game.airmash.cc|dev


### PR DESCRIPTION
This changes the domain back to a proper one with working certificates so that it's no longer necessary to proxy to the servers.

Closes #6.